### PR TITLE
Generate more useful /etc/fstab entries when using loopbacked files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This cookbook supports four main types of block devices:
 * normal `device` - drives, ssds, volumes presented by HBAs etc
 * device ID `uuid` - mostly found on drives / known block IDs.
 * LVM Volume Groups `vg` - found on systems using LVM.
-* file-backed `file` - created dynamically and looped back - will not come up on reboot, but we will try to remount existing `file` storage in chef.
+* file-backed `file` - created dynamically and looped back.
 
 We will try to create filesystems in two ways: through keys found in node data under 'filesystems' or by being called directly with the `filesystem` default provider. See the example recipe.
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -164,6 +164,7 @@ action :enable do
   pass = @new_resource.pass
   dump = @new_resource.dump
   options = @new_resource.options
+  file = @new_resource.file
 
   if mount
 
@@ -175,10 +176,17 @@ action :enable do
       mode mode if mode
     end
 
+    # Substitute the device with the file when in loopback mode.
+    # This should allow the mount to come back up on reboot.
+    device_or_file = device
+    if file && device.start_with?('/dev/loop')
+      device_or_file = file
+      options = [options, "loop=#{device}"].compact.join(',')
+    end
+
     # Mount using the chef resource
     mount mount do
-      device device
-      fstype fstype
+      device device_or_file
       pass pass
       dump dump
       options options


### PR DESCRIPTION
This PR generates fstab entries for files that use the `-o loop`; this should help with remounting the loopback volumes on reboot and not only when chef-client runs.

No tests but the code should be simple enough.
On my test-kitchen, converging the following resource:

```ruby
filesystem "docker" do
  fstype "btrfs"
  device '/dev/loop0'
  file '/opt/docker-fs'
  size '3000'
  mount '/var/lib/docker'
  action [:create, :enable, :mount]
end
```

Has the following effects

```sh
vagrant@deployments-ubuntu-1404:~$ mount | grep loop0
/dev/loop0 on /var/lib/docker type btrfs (rw)
vagrant@deployments-ubuntu-1404:~$ cat /etc/fstab | grep loop0
/opt/docker-fs /var/lib/docker auto defaults,loop=/dev/loop0 0 0
```