### PR TITLE
renaming the Filesystem module, to fix a crash with chef 12.0.0

### DIFF
--- a/libraries/fs.rb
+++ b/libraries/fs.rb
@@ -1,7 +1,7 @@
 require 'pathname'
 require 'chef/mixin/shell_out'
 
-module Filesystem
+module FilesystemMod
   include Chef::Mixin::ShellOut
 
   MOUNT_EX_FAIL = 32 unless const_defined?(:MOUNT_EX_FAIL)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -19,7 +19,7 @@
 
 use_inline_resources
 
-include Filesystem
+include FilesystemMod
 
 action :create do
 


### PR DESCRIPTION
Fixes this problem on Chef version 12.0.0:

 ================================================================================
    Error executing action `create` on resource 'filesystem[ehemerals]'
    ================================================================================
    
    NoMethodError
    -------------
    undefined method `new' for Filesystem:Module
