### PR TITLE
Weaken pessimistic version range on lvm

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ version          "0.9.0"
   supports os
 end
 
-depends 'lvm', '~> 1.1.0'
+depends 'lvm', '~> 1.1'
 
 attribute 'filesystems',
   :description => "Filesystems to be created and/or mounted",


### PR DESCRIPTION
Is there a need to lock down the lvm cookbook's use to 1.1.x? I have cookbooks that need lvm >= 1.3.